### PR TITLE
Update composition functions to v1

### DIFF
--- a/fn.go
+++ b/fn.go
@@ -17,7 +17,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
 
-	fnv1beta1 "github.com/crossplane/function-sdk-go/proto/v1beta1"
+	fnv1 "github.com/crossplane/function-sdk-go/proto/v1"
 	"github.com/crossplane/function-sdk-go/request"
 	"github.com/crossplane/function-sdk-go/response"
 
@@ -30,13 +30,13 @@ const (
 
 // Function returns whatever response you ask it to.
 type Function struct {
-	fnv1beta1.UnimplementedFunctionRunnerServiceServer
+	fnv1.UnimplementedFunctionRunnerServiceServer
 
 	log logging.Logger
 }
 
 // RunFunction runs the Function.
-func (f *Function) RunFunction(_ context.Context, req *fnv1beta1.RunFunctionRequest) (*fnv1beta1.RunFunctionResponse, error) {
+func (f *Function) RunFunction(_ context.Context, req *fnv1.RunFunctionRequest) (*fnv1.RunFunctionResponse, error) {
 	f.log.Info("Running function", "tag", req.GetMeta().GetTag())
 
 	rsp := response.To(req, response.DefaultTTL)
@@ -257,16 +257,16 @@ func sortExtrasByFieldPath(extras []resource.Extra, path string) error { //nolin
 	return nil
 }
 
-func buildRequirements(in *v1beta1.Input, xr *resource.Composite) (*fnv1beta1.Requirements, error) {
-	extraResources := make(map[string]*fnv1beta1.ResourceSelector, len(in.Spec.EnvironmentConfigs))
+func buildRequirements(in *v1beta1.Input, xr *resource.Composite) (*fnv1.Requirements, error) {
+	extraResources := make(map[string]*fnv1.ResourceSelector, len(in.Spec.EnvironmentConfigs))
 	for i, config := range in.Spec.EnvironmentConfigs {
 		extraResName := fmt.Sprintf("environment-config-%d", i)
 		switch config.Type {
 		case v1beta1.EnvironmentSourceTypeReference, "":
-			extraResources[extraResName] = &fnv1beta1.ResourceSelector{
+			extraResources[extraResName] = &fnv1.ResourceSelector{
 				ApiVersion: "apiextensions.crossplane.io/v1alpha1",
 				Kind:       "EnvironmentConfig",
-				Match: &fnv1beta1.ResourceSelector_MatchName{
+				Match: &fnv1.ResourceSelector_MatchName{
 					MatchName: config.Ref.Name,
 				},
 			}
@@ -291,16 +291,16 @@ func buildRequirements(in *v1beta1.Input, xr *resource.Composite) (*fnv1beta1.Re
 			if len(matchLabels) == 0 {
 				continue
 			}
-			extraResources[extraResName] = &fnv1beta1.ResourceSelector{
+			extraResources[extraResName] = &fnv1.ResourceSelector{
 				ApiVersion: "apiextensions.crossplane.io/v1alpha1",
 				Kind:       "EnvironmentConfig",
-				Match: &fnv1beta1.ResourceSelector_MatchLabels{
-					MatchLabels: &fnv1beta1.MatchLabels{Labels: matchLabels},
+				Match: &fnv1.ResourceSelector_MatchLabels{
+					MatchLabels: &fnv1.MatchLabels{Labels: matchLabels},
 				},
 			}
 		}
 	}
-	return &fnv1beta1.Requirements{ExtraResources: extraResources}, nil
+	return &fnv1.Requirements{ExtraResources: extraResources}, nil
 }
 
 func mergeEnvConfigsData(configs []unstructured.Unstructured) (map[string]interface{}, error) {

--- a/fn_test.go
+++ b/fn_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
 
-	fnv1beta1 "github.com/crossplane/function-sdk-go/proto/v1beta1"
+	fnv1 "github.com/crossplane/function-sdk-go/proto/v1"
 	"github.com/crossplane/function-sdk-go/resource"
 	"github.com/crossplane/function-sdk-go/response"
 )
@@ -23,10 +23,10 @@ func TestRunFunction(t *testing.T) {
 
 	type args struct {
 		ctx context.Context
-		req *fnv1beta1.RunFunctionRequest
+		req *fnv1.RunFunctionRequest
 	}
 	type want struct {
-		rsp *fnv1beta1.RunFunctionResponse
+		rsp *fnv1.RunFunctionResponse
 		err error
 	}
 
@@ -38,10 +38,10 @@ func TestRunFunction(t *testing.T) {
 		"RequestEnvironmentConfigs": {
 			reason: "The Function should request the necessary EnvironmentConfigs",
 			args: args{
-				req: &fnv1beta1.RunFunctionRequest{
-					Meta: &fnv1beta1.RequestMeta{Tag: "hello"},
-					Observed: &fnv1beta1.State{
-						Composite: &fnv1beta1.Resource{
+				req: &fnv1.RunFunctionRequest{
+					Meta: &fnv1.RequestMeta{Tag: "hello"},
+					Observed: &fnv1.State{
+						Composite: &fnv1.Resource{
 							Resource: resource.MustStructJSON(`{
 								"apiVersion": "test.crossplane.io/v1alpha1",
 								"kind": "XR",
@@ -116,30 +116,30 @@ func TestRunFunction(t *testing.T) {
 				},
 			},
 			want: want{
-				rsp: &fnv1beta1.RunFunctionResponse{
-					Meta:    &fnv1beta1.ResponseMeta{Tag: "hello", Ttl: durationpb.New(response.DefaultTTL)},
-					Results: []*fnv1beta1.Result{},
-					Requirements: &fnv1beta1.Requirements{
-						ExtraResources: map[string]*fnv1beta1.ResourceSelector{
+				rsp: &fnv1.RunFunctionResponse{
+					Meta:    &fnv1.ResponseMeta{Tag: "hello", Ttl: durationpb.New(response.DefaultTTL)},
+					Results: []*fnv1.Result{},
+					Requirements: &fnv1.Requirements{
+						ExtraResources: map[string]*fnv1.ResourceSelector{
 							"environment-config-0": {
 								ApiVersion: "apiextensions.crossplane.io/v1alpha1",
 								Kind:       "EnvironmentConfig",
-								Match: &fnv1beta1.ResourceSelector_MatchName{
+								Match: &fnv1.ResourceSelector_MatchName{
 									MatchName: "my-env-config",
 								},
 							},
 							"environment-config-1": {
 								ApiVersion: "apiextensions.crossplane.io/v1alpha1",
 								Kind:       "EnvironmentConfig",
-								Match: &fnv1beta1.ResourceSelector_MatchName{
+								Match: &fnv1.ResourceSelector_MatchName{
 									MatchName: "my-second-env-config",
 								},
 							},
 							"environment-config-2": {
 								ApiVersion: "apiextensions.crossplane.io/v1alpha1",
 								Kind:       "EnvironmentConfig",
-								Match: &fnv1beta1.ResourceSelector_MatchLabels{
-									MatchLabels: &fnv1beta1.MatchLabels{
+								Match: &fnv1.ResourceSelector_MatchLabels{
+									MatchLabels: &fnv1.MatchLabels{
 										Labels: map[string]string{
 											"foo": "bar",
 										},
@@ -150,8 +150,8 @@ func TestRunFunction(t *testing.T) {
 							"environment-config-4": {
 								ApiVersion: "apiextensions.crossplane.io/v1alpha1",
 								Kind:       "EnvironmentConfig",
-								Match: &fnv1beta1.ResourceSelector_MatchLabels{
-									MatchLabels: &fnv1beta1.MatchLabels{
+								Match: &fnv1.ResourceSelector_MatchLabels{
+									MatchLabels: &fnv1.MatchLabels{
 										Labels: map[string]string{
 											"someMoreFoo": "someMoreBar",
 										},
@@ -166,10 +166,10 @@ func TestRunFunction(t *testing.T) {
 		"RequestEnvironmentConfigsFound": {
 			reason: "The Function should request the necessary EnvironmentConfigs even if they are already present in the request",
 			args: args{
-				req: &fnv1beta1.RunFunctionRequest{
-					Meta: &fnv1beta1.RequestMeta{Tag: "hello"},
-					Observed: &fnv1beta1.State{
-						Composite: &fnv1beta1.Resource{
+				req: &fnv1.RunFunctionRequest{
+					Meta: &fnv1.RequestMeta{Tag: "hello"},
+					Observed: &fnv1.State{
+						Composite: &fnv1.Resource{
 							Resource: resource.MustStructJSON(`{
 								"apiVersion": "test.crossplane.io/v1alpha1",
 								"kind": "XR",
@@ -182,9 +182,9 @@ func TestRunFunction(t *testing.T) {
 							}`),
 						},
 					},
-					ExtraResources: map[string]*fnv1beta1.Resources{
+					ExtraResources: map[string]*fnv1.Resources{
 						"environment-config-0": {
-							Items: []*fnv1beta1.Resource{
+							Items: []*fnv1.Resource{
 								{
 									Resource: resource.MustStructJSON(`{
 									"apiVersion": "apiextensions.crossplane.io/v1alpha1",
@@ -201,7 +201,7 @@ func TestRunFunction(t *testing.T) {
 							},
 						},
 						"environment-config-1": {
-							Items: []*fnv1beta1.Resource{
+							Items: []*fnv1.Resource{
 								{
 									Resource: resource.MustStructJSON(`{
 									"apiVersion": "apiextensions.crossplane.io/v1alpha1",
@@ -218,7 +218,7 @@ func TestRunFunction(t *testing.T) {
 							},
 						},
 						"environment-config-2": {
-							Items: []*fnv1beta1.Resource{
+							Items: []*fnv1.Resource{
 								{
 									Resource: resource.MustStructJSON(`{
 									"apiVersion": "apiextensions.crossplane.io/v1alpha1",
@@ -246,7 +246,7 @@ func TestRunFunction(t *testing.T) {
 							},
 						},
 						"environment-config-3": {
-							Items: []*fnv1beta1.Resource{
+							Items: []*fnv1.Resource{
 								{
 									Resource: resource.MustStructJSON(`{
 									"apiVersion": "apiextensions.crossplane.io/v1alpha1",
@@ -262,7 +262,7 @@ func TestRunFunction(t *testing.T) {
 							},
 						},
 						"environment-config-4": {
-							Items: []*fnv1beta1.Resource{
+							Items: []*fnv1.Resource{
 								{
 									Resource: resource.MustStructJSON(`{
 									"apiVersion": "apiextensions.crossplane.io/v1alpha1",
@@ -340,30 +340,30 @@ func TestRunFunction(t *testing.T) {
 				},
 			},
 			want: want{
-				rsp: &fnv1beta1.RunFunctionResponse{
-					Meta:    &fnv1beta1.ResponseMeta{Tag: "hello", Ttl: durationpb.New(response.DefaultTTL)},
-					Results: []*fnv1beta1.Result{},
-					Requirements: &fnv1beta1.Requirements{
-						ExtraResources: map[string]*fnv1beta1.ResourceSelector{
+				rsp: &fnv1.RunFunctionResponse{
+					Meta:    &fnv1.ResponseMeta{Tag: "hello", Ttl: durationpb.New(response.DefaultTTL)},
+					Results: []*fnv1.Result{},
+					Requirements: &fnv1.Requirements{
+						ExtraResources: map[string]*fnv1.ResourceSelector{
 							"environment-config-0": {
 								ApiVersion: "apiextensions.crossplane.io/v1alpha1",
 								Kind:       "EnvironmentConfig",
-								Match: &fnv1beta1.ResourceSelector_MatchName{
+								Match: &fnv1.ResourceSelector_MatchName{
 									MatchName: "my-env-config",
 								},
 							},
 							"environment-config-1": {
 								ApiVersion: "apiextensions.crossplane.io/v1alpha1",
 								Kind:       "EnvironmentConfig",
-								Match: &fnv1beta1.ResourceSelector_MatchName{
+								Match: &fnv1.ResourceSelector_MatchName{
 									MatchName: "my-second-env-config",
 								},
 							},
 							"environment-config-2": {
 								ApiVersion: "apiextensions.crossplane.io/v1alpha1",
 								Kind:       "EnvironmentConfig",
-								Match: &fnv1beta1.ResourceSelector_MatchLabels{
-									MatchLabels: &fnv1beta1.MatchLabels{
+								Match: &fnv1.ResourceSelector_MatchLabels{
+									MatchLabels: &fnv1.MatchLabels{
 										Labels: map[string]string{
 											"foo": "bar",
 										},
@@ -374,8 +374,8 @@ func TestRunFunction(t *testing.T) {
 							"environment-config-4": {
 								ApiVersion: "apiextensions.crossplane.io/v1alpha1",
 								Kind:       "EnvironmentConfig",
-								Match: &fnv1beta1.ResourceSelector_MatchLabels{
-									MatchLabels: &fnv1beta1.MatchLabels{
+								Match: &fnv1.ResourceSelector_MatchLabels{
+									MatchLabels: &fnv1.MatchLabels{
 										Labels: map[string]string{
 											"someMoreFoo": "someMoreBar",
 										},
@@ -404,10 +404,10 @@ func TestRunFunction(t *testing.T) {
 		"RequestEnvironmentConfigsNotFoundRequired": {
 			reason: "The Function should return fatal if a required EnvironmentConfig is not found",
 			args: args{
-				req: &fnv1beta1.RunFunctionRequest{
-					Meta: &fnv1beta1.RequestMeta{Tag: "hello"},
-					Observed: &fnv1beta1.State{
-						Composite: &fnv1beta1.Resource{
+				req: &fnv1.RunFunctionRequest{
+					Meta: &fnv1.RequestMeta{Tag: "hello"},
+					Observed: &fnv1.State{
+						Composite: &fnv1.Resource{
 							Resource: resource.MustStructJSON(`{
 								"apiVersion": "test.crossplane.io/v1alpha1",
 								"kind": "XR",
@@ -417,9 +417,9 @@ func TestRunFunction(t *testing.T) {
 							}`),
 						},
 					},
-					ExtraResources: map[string]*fnv1beta1.Resources{
+					ExtraResources: map[string]*fnv1.Resources{
 						"environment-config-0": {
-							Items: []*fnv1beta1.Resource{},
+							Items: []*fnv1.Resource{},
 						},
 					},
 					Input: resource.MustStructJSON(`{
@@ -439,19 +439,20 @@ func TestRunFunction(t *testing.T) {
 				},
 			},
 			want: want{
-				rsp: &fnv1beta1.RunFunctionResponse{
-					Meta: &fnv1beta1.ResponseMeta{Tag: "hello", Ttl: durationpb.New(response.DefaultTTL)},
-					Results: []*fnv1beta1.Result{
+				rsp: &fnv1.RunFunctionResponse{
+					Meta: &fnv1.ResponseMeta{Tag: "hello", Ttl: durationpb.New(response.DefaultTTL)},
+					Results: []*fnv1.Result{
 						{
-							Severity: fnv1beta1.Severity_SEVERITY_FATAL,
+							Severity: fnv1.Severity_SEVERITY_FATAL,
+							Target:   fnv1.Target_TARGET_COMPOSITE.Enum(),
 						},
 					},
-					Requirements: &fnv1beta1.Requirements{
-						ExtraResources: map[string]*fnv1beta1.ResourceSelector{
+					Requirements: &fnv1.Requirements{
+						ExtraResources: map[string]*fnv1.ResourceSelector{
 							"environment-config-0": {
 								ApiVersion: "apiextensions.crossplane.io/v1alpha1",
 								Kind:       "EnvironmentConfig",
-								Match: &fnv1beta1.ResourceSelector_MatchName{
+								Match: &fnv1.ResourceSelector_MatchName{
 									MatchName: "my-env-config",
 								},
 							},
@@ -463,8 +464,8 @@ func TestRunFunction(t *testing.T) {
 		"MergeEnvironmentConfigs": {
 			reason: "The Function should merge the provided EnvironmentConfigs",
 			args: args{
-				req: &fnv1beta1.RunFunctionRequest{
-					Meta: &fnv1beta1.RequestMeta{Tag: "hello"},
+				req: &fnv1.RunFunctionRequest{
+					Meta: &fnv1.RequestMeta{Tag: "hello"},
 					Context: resource.MustStructJSON(`{
 						"` + FunctionContextKeyEnvironment + `": {
 							"apiVersion": "internal.crossplane.io/v1alpha1",
@@ -500,9 +501,9 @@ func TestRunFunction(t *testing.T) {
 							]
 						}
 					}`),
-					ExtraResources: map[string]*fnv1beta1.Resources{
+					ExtraResources: map[string]*fnv1.Resources{
 						"environment-config-0": {
-							Items: []*fnv1beta1.Resource{
+							Items: []*fnv1.Resource{
 								{
 									Resource: resource.MustStructJSON(`{
 									"apiVersion": "apiextensions.crossplane.io/v1alpha1",
@@ -520,7 +521,7 @@ func TestRunFunction(t *testing.T) {
 							},
 						},
 						"environment-config-1": {
-							Items: []*fnv1beta1.Resource{
+							Items: []*fnv1.Resource{
 								{
 									Resource: resource.MustStructJSON(`{
 									"apiVersion": "apiextensions.crossplane.io/v1alpha1",
@@ -541,22 +542,22 @@ func TestRunFunction(t *testing.T) {
 				},
 			},
 			want: want{
-				rsp: &fnv1beta1.RunFunctionResponse{
-					Meta:    &fnv1beta1.ResponseMeta{Tag: "hello", Ttl: durationpb.New(response.DefaultTTL)},
-					Results: []*fnv1beta1.Result{},
-					Requirements: &fnv1beta1.Requirements{
-						ExtraResources: map[string]*fnv1beta1.ResourceSelector{
+				rsp: &fnv1.RunFunctionResponse{
+					Meta:    &fnv1.ResponseMeta{Tag: "hello", Ttl: durationpb.New(response.DefaultTTL)},
+					Results: []*fnv1.Result{},
+					Requirements: &fnv1.Requirements{
+						ExtraResources: map[string]*fnv1.ResourceSelector{
 							"environment-config-0": {
 								ApiVersion: "apiextensions.crossplane.io/v1alpha1",
 								Kind:       "EnvironmentConfig",
-								Match: &fnv1beta1.ResourceSelector_MatchName{
+								Match: &fnv1.ResourceSelector_MatchName{
 									MatchName: "my-env-config",
 								},
 							},
 							"environment-config-1": {
 								ApiVersion: "apiextensions.crossplane.io/v1alpha1",
 								Kind:       "EnvironmentConfig",
-								Match: &fnv1beta1.ResourceSelector_MatchName{
+								Match: &fnv1.ResourceSelector_MatchName{
 									MatchName: "my-second-env-config",
 								},
 							},
@@ -588,7 +589,7 @@ func TestRunFunction(t *testing.T) {
 			f := &Function{log: logging.NewNopLogger()}
 			rsp, err := f.RunFunction(tc.args.ctx, tc.args.req)
 
-			diff := cmp.Diff(tc.want.rsp, rsp, cmpopts.AcyclicTransformer("toJsonWithoutResultMessages", func(r *fnv1beta1.RunFunctionResponse) []byte {
+			diff := cmp.Diff(tc.want.rsp, rsp, cmpopts.AcyclicTransformer("toJsonWithoutResultMessages", func(r *fnv1.RunFunctionResponse) []byte {
 				// We don't care about messages.
 				// cmptopts.IgnoreField wasn't working with protocmp.Transform
 				// We can't split this to another transformer as


### PR DESCRIPTION
### Description of your changes

Update composition functions to v1

In order to update function-sdk-go to v0.3.0 it is required to bump composition functions to v1.
This is required by change https://github.com/crossplane/function-sdk-go/pull/155 and described in the release notes for function-sdk-go v0.3.0

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
