### PR TITLE
Use distroless/static image instead of distroless/base since glibc is not used

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN --mount=target=. \
 
 # Produce the Function image. We use a very lightweight 'distroless' image that
 # does not include any of the build tools used in previous stages.
-FROM gcr.io/distroless/base-debian11 AS image
+FROM gcr.io/distroless/static-debian12:nonroot AS image
 WORKDIR /
 COPY --from=build /function /function
 EXPOSE 9443


### PR DESCRIPTION
### Description of your changes

This pull request changes the base image of the function to `gcr.io/distroless/static-debian12:nonroot`.

Fixes #51

I have:

- [x] Read and followed Crossplane's [contribution process].
~- [ ] Added or updated unit tests for my change.~

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute