### PR TITLE
output envconfig name if missing instead of generic extra resource name

### DIFF
--- a/fn.go
+++ b/fn.go
@@ -141,14 +141,15 @@ func getSelectedEnvConfigs(in *v1beta1.Input, extraResources map[string][]resour
 		}
 		switch config.GetType() {
 		case v1beta1.EnvironmentSourceTypeReference:
+			envConfigName := config.Ref.Name
 			if len(resources) == 0 {
 				if in.Spec.Policy.IsResolutionPolicyOptional() {
 					continue
 				}
-				return nil, errors.Errorf("Required environment config %q not found", extraResName)
+				return nil, errors.Errorf("Required environment config %q not found", envConfigName)
 			}
 			if len(resources) > 1 {
-				return nil, errors.Errorf("expected exactly one extra resource %q, got %d", extraResName, len(resources))
+				return nil, errors.Errorf("expected exactly one extra resource %q, got %d", envConfigName, len(resources))
 			}
 			envConfigs = append(envConfigs, *resources[0].Resource)
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Display the envconfig name in case it's missing

Executing 

`$ crossplane render   --extra-resources example/environmentConfigs.yaml   --include-context   example/xr.yaml example/composition.yaml example/functions.yaml`

Will output the name of the missing envconfig in the error message:

`crossplane: error: cannot render composite resource: pipeline step "environmentConfigs" returned a fatal result: cannot get selected environment configs: Required environment config "missing-envconfig" not found`

instead of

`crossplane: error: cannot render composite resource: pipeline step "environmentConfigs" returned a fatal result: cannot get selected environment configs: Required environment config "environment-config-0" not found`

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes #60 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
