### PR TITLE
feat: bump crossplane required version to 1.18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
   # Common versions
   GO_VERSION: '1.23.3'
   GOLANGCI_VERSION: 'v1.62.2'
-  DOCKER_BUILDX_VERSION: 'v0.11.2'
+  DOCKER_BUILDX_VERSION: 'v0.23.0'
 
   # These environment variables are important to the Crossplane CLI install.sh
   # script. They determine what version it installs.

--- a/package/crossplane.yaml
+++ b/package/crossplane.yaml
@@ -20,4 +20,4 @@ metadata:
       spec.environment.environmentConfigs.
 spec:
   crossplane:
-    version: ">=v1.15.0-0"
+    version: ">=v1.18.0-0"


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

With XP 1.21, all supported versions will define both alpha and beta versions of EnvironmentConfigs, so we switched this function to use `v1beta1`, this shouldn't change anything for real deployments, but will mean people passing `v1alpha1` `EnvironmentConfigs` to commands such as `crossplane beta render` as `extra resources` will have to switch to `v1beta1`.

Follow up to https://github.com/crossplane-contrib/function-environment-configs/pull/58

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
