### PR TITLE
Allow optional environment configs

### DIFF
--- a/fn.go
+++ b/fn.go
@@ -138,7 +138,8 @@ func getSelectedEnvConfigs(in *v1beta1.Input, extraResources map[string][]resour
 		extraResName := fmt.Sprintf("environment-config-%d", i)
 		resources, ok := extraResources[extraResName]
 		if !ok {
-			return nil, errors.Errorf("cannot find expected extra resource %q", extraResName)
+			// Skip if the extra resource was not requested (e.g., optional selector with no matchLabels)
+			continue
 		}
 		switch config.GetType() {
 		case v1beta1.EnvironmentSourceTypeReference:


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes the function to gracefully skip selectors with optional field paths when the field doesn't exist on the
  composite resource, as documented for Single mode.

  **Problem:** When using a Selector with `fromFieldPathPolicy: Optional` and the referenced field doesn't exist:
  - `buildRequirements` correctly skips adding the selector to requirements
  - But `getSelectedEnvConfigs` expects ALL configs in the input spec to have corresponding entries in
  `extraResources`
  - This causes a fatal error: "cannot find expected extra resource environment-config-N"

  **Solution:** Modified `getSelectedEnvConfigs` (line 140-142) to skip environment configs that are not present
  in `extraResources`, rather than erroring out.

  ```go
  // OLD (buggy):
  resources, ok := extraResources[extraResName]
  if !ok {
      return nil, errors.Errorf("cannot find expected extra resource %q", extraResName)
  }

  // NEW (fixed):
  resources, ok := extraResources[extraResName]
  if !ok {
      // Skip if the extra resource was not requested (e.g., optional selector with no matchLabels)
      continue
  }
  ```

  This allows selectors with optional field paths to be truly optional, supporting the documented behavior for
  Single mode: "if 'Optional' is set the label pair will be skipped if the field does not exist and other
  matchingLabels will be used **if any others exist**."

## Test Coverage

  Added two comprehensive test cases:

  ### 1. `TestRunFunction/SelectorWithOptionalFieldPathNotProvided`
  Tests Multiple mode with `minMatch: 0` when optional field doesn't exist:
  - Input spec has 2 environment configs (Reference + Selector with optional field path)
  - Selector is NOT added to requirements (field doesn't exist)
  - Only base config is in `extraResources`
  - ✅ **With fix:** Function succeeds, merges only base config
  - ❌ **Without fix:** SEVERITY_FATAL error

  ### 2. `TestRunFunction/SelectorSingleModeWithOptionalFieldPathNotProvided`
  Tests Single mode when optional field doesn't exist (per documentation):
  - Input spec has 2 environment configs (Reference + Single mode Selector with optional field path)
  - Selector is NOT added to requirements (field doesn't exist)
  - Only base config is in `extraResources`
  - ✅ **With fix:** Function succeeds, merges only base config
  - ❌ **Without fix:** SEVERITY_FATAL error

  Both tests verify that:
  1. The fix allows the function to proceed successfully
  2. Without the fix, the same scenario produces a fatal error
  3. The environment context is correctly populated with only the base config

  ## Testing

  ```bash
  # Run all tests
  go test -v

  # Run specific new tests
  go test -v -run TestRunFunction/SelectorWithOptionalFieldPathNotProvided
  go test -v -run TestRunFunction/SelectorSingleModeWithOptionalFieldPathNotProvided
  ```

  All existing tests continue to pass, confirming backward compatibility.

Fixes #86

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
