### PR TITLE
pkg: switch Function package APIs from v1beta1 to v1

### DIFF
--- a/examples/kubecon-2024/functions.yaml
+++ b/examples/kubecon-2024/functions.yaml
@@ -1,12 +1,12 @@
 ---
-apiVersion: pkg.crossplane.io/v1beta1
+apiVersion: pkg.crossplane.io/v1
 kind: Function
 metadata:
   name: function-environment-configs
 spec:
   package: xpkg.upbound.io/crossplane-contrib/function-environment-configs:v0.4.0
 ---
-apiVersion: pkg.crossplane.io/v1beta1
+apiVersion: pkg.crossplane.io/v1
 kind: Function
 metadata:
   name: function-go-templating

--- a/examples/match_label_multiple/functions.yaml
+++ b/examples/match_label_multiple/functions.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: pkg.crossplane.io/v1beta1
+apiVersion: pkg.crossplane.io/v1
 kind: Function
 metadata:
   name: function-environment-configs
@@ -10,7 +10,7 @@ spec:
   # This is ignored when using the Development runtime.
   package: xpkg.upbound.io/crossplane-contrib/function-environment-configs:v0.4.0
 ---
-apiVersion: pkg.crossplane.io/v1beta1
+apiVersion: pkg.crossplane.io/v1
 kind: Function
 metadata:
   name: function-go-templating

--- a/examples/match_label_single/functions.yaml
+++ b/examples/match_label_single/functions.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: pkg.crossplane.io/v1beta1
+apiVersion: pkg.crossplane.io/v1
 kind: Function
 metadata:
   name: function-environment-configs
@@ -10,7 +10,7 @@ spec:
   # This is ignored when using the Development runtime.
   package: xpkg.upbound.io/crossplane-contrib/function-environment-configs:v0.4.0
 ---
-apiVersion: pkg.crossplane.io/v1beta1
+apiVersion: pkg.crossplane.io/v1
 kind: Function
 metadata:
   name: function-go-templating

--- a/examples/reference_name/functions.yaml
+++ b/examples/reference_name/functions.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: pkg.crossplane.io/v1beta1
+apiVersion: pkg.crossplane.io/v1
 kind: Function
 metadata:
   name: function-environment-configs
@@ -10,7 +10,7 @@ spec:
   # This is ignored when using the Development runtime.
   package: xpkg.upbound.io/crossplane-contrib/function-environment-configs:v0.4.0
 ---
-apiVersion: pkg.crossplane.io/v1beta1
+apiVersion: pkg.crossplane.io/v1
 kind: Function
 metadata:
   name: function-go-templating

--- a/package/crossplane.yaml
+++ b/package/crossplane.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: meta.pkg.crossplane.io/v1beta1
+apiVersion: meta.pkg.crossplane.io/v1
 kind: Function
 metadata:
   name: function-environment-configs


### PR DESCRIPTION
### Description

This PR updates Function package manifests to use `v1` instead of `v1beta1` for:

- `meta.pkg.crossplane.io`
- `pkg.crossplane.io`

Both `Function` and `FunctionRevision` already use `v1` as their storage version, so this change does not affect existing Crossplane installations when  Crossplane >= 1.17.x

The change only impacts newly built function packages, which will now be published using `v1`. Installing or upgrading these packages in an existing control plane works without disruption.

Related issue: https://github.com/crossplane/crossplane/issues/6947