### PR TITLE
feat: configurable environment path

### DIFF
--- a/fn.go
+++ b/fn.go
@@ -135,7 +135,9 @@ func (f *Function) RunFunction(_ context.Context, req *fnv1.RunFunctionRequest) 
 	return rsp, nil
 }
 
-func getSelectedEnvConfigs(in *v1beta1.Input, requiredResources map[string][]resource.Required) (envConfigs []unstructured.Unstructured, err error) {
+func getSelectedEnvConfigs(in *v1beta1.Input, requiredResources map[string][]resource.Required) (map[string][]unstructured.Unstructured, error) {
+	envConfigs := make(map[string][]unstructured.Unstructured)
+
 	for i, config := range in.Spec.EnvironmentConfigs {
 		extraResName := fmt.Sprintf("environment-config-%d", i)
 		resources, ok := requiredResources[extraResName]
@@ -144,7 +146,11 @@ func getSelectedEnvConfigs(in *v1beta1.Input, requiredResources map[string][]res
 			continue
 		}
 
-		var processed []unstructured.Unstructured
+		toFieldPath := ""
+		if config.ToFieldPath != nil {
+			toFieldPath = *config.ToFieldPath
+		}
+
 		switch config.GetType() {
 		case v1beta1.EnvironmentSourceTypeReference:
 			out, err := processSourceByReference(in, config, resources)
@@ -154,38 +160,19 @@ func getSelectedEnvConfigs(in *v1beta1.Input, requiredResources map[string][]res
 			if out == nil {
 				continue
 			}
-			processed = []unstructured.Unstructured{*out}
+			envConfigs[toFieldPath] = append(envConfigs[toFieldPath], *out)
 
 		case v1beta1.EnvironmentSourceTypeSelector:
 			out, err := processEnvironmentSource(config, resources)
 			if err != nil {
 				return nil, errors.Wrapf(err, "cannot process environment config %q by selector", extraResName)
 			}
-			processed = out
+			if len(out) > 0 {
+				envConfigs[toFieldPath] = append(envConfigs[toFieldPath], out...)
+			}
 		}
-
-		if err := moveDataToFieldPath(config.ToFieldPath, processed); err != nil {
-			return nil, err
-		}
-		envConfigs = append(envConfigs, processed...)
 	}
 	return envConfigs, nil
-}
-
-func moveDataToFieldPath(fieldPath *string, envConfigs []unstructured.Unstructured) error {
-	if fieldPath == nil {
-		return nil
-	}
-
-	for _, e := range envConfigs {
-		data := e.Object["data"]
-		delete(e.Object, "data")
-
-		if err := fieldpath.Pave(e.Object).SetValue("data."+*fieldPath, data); err != nil {
-			return errors.Errorf("Unable to move environment to target path '%s'", *fieldPath)
-		}
-	}
-	return nil
 }
 
 func processEnvironmentSource(config v1beta1.EnvironmentSource, resources []resource.Required) ([]unstructured.Unstructured, error) {
@@ -373,15 +360,23 @@ func buildRequirements(in *v1beta1.Input, xr *resource.Composite) (*fnv1.Require
 	return &fnv1.Requirements{Resources: resources}, nil
 }
 
-func mergeEnvConfigsData(configs []unstructured.Unstructured) (map[string]any, error) {
+func mergeEnvConfigsData(configsByField map[string][]unstructured.Unstructured) (map[string]interface{}, error) {
 	merged := map[string]any{}
-	for _, c := range configs {
-		data := map[string]any{}
-		if err := fieldpath.Pave(c.Object).GetValueInto("data", &data); err != nil {
-			return nil, errors.Wrapf(err, "cannot get data from environment config %q", c.GetName())
-		}
+	for fieldPath, configs := range configsByField {
+		for _, c := range configs {
+			data := map[string]any{}
+			if fieldPath != "" {
+				if err := fieldpath.Pave(data).SetValue(fieldPath, c.Object["data"]); err != nil {
+					return nil, errors.Errorf("cannot get data from environment config %s into path %q", c.GetName(), fieldPath)
+				}
+			} else {
+				if err := fieldpath.Pave(c.Object).GetValueInto("data", &data); err != nil {
+					return nil, errors.Wrapf(err, "cannot get data from environment config %q", c.GetName())
+				}
+			}
 
-		merged = mergeMaps(merged, data)
+			merged = mergeMaps(merged, data)
+		}
 	}
 	return merged, nil
 }

--- a/fn.go
+++ b/fn.go
@@ -143,6 +143,8 @@ func getSelectedEnvConfigs(in *v1beta1.Input, requiredResources map[string][]res
 			// Skip if the required resource was not requested (e.g., optional selector with no matchLabels)
 			continue
 		}
+
+		var processed []unstructured.Unstructured
 		switch config.GetType() {
 		case v1beta1.EnvironmentSourceTypeReference:
 			out, err := processSourceByReference(in, config, resources)
@@ -152,19 +154,38 @@ func getSelectedEnvConfigs(in *v1beta1.Input, requiredResources map[string][]res
 			if out == nil {
 				continue
 			}
-			envConfigs = append(envConfigs, *out)
+			processed = []unstructured.Unstructured{*out}
 
 		case v1beta1.EnvironmentSourceTypeSelector:
 			out, err := processEnvironmentSource(config, resources)
 			if err != nil {
 				return nil, errors.Wrapf(err, "cannot process environment config %q by selector", extraResName)
 			}
-			if len(out) > 0 {
-				envConfigs = append(envConfigs, out...)
-			}
+			processed = out
 		}
+
+		if err := moveDataToFieldPath(config.ToFieldPath, processed); err != nil {
+			return nil, err
+		}
+		envConfigs = append(envConfigs, processed...)
 	}
 	return envConfigs, nil
+}
+
+func moveDataToFieldPath(fieldPath *string, envConfigs []unstructured.Unstructured) error {
+	if fieldPath == nil {
+		return nil
+	}
+
+	for _, e := range envConfigs {
+		data := e.Object["data"]
+		delete(e.Object, "data")
+
+		if err := fieldpath.Pave(e.Object).SetValue("data."+*fieldPath, data); err != nil {
+			return errors.Errorf("Unable to move environment to target path '%s'", *fieldPath)
+		}
+	}
+	return nil
 }
 
 func processEnvironmentSource(config v1beta1.EnvironmentSource, resources []resource.Required) ([]unstructured.Unstructured, error) {

--- a/fn.go
+++ b/fn.go
@@ -360,7 +360,7 @@ func buildRequirements(in *v1beta1.Input, xr *resource.Composite) (*fnv1.Require
 	return &fnv1.Requirements{Resources: resources}, nil
 }
 
-func mergeEnvConfigsData(configsByField map[string][]unstructured.Unstructured) (map[string]interface{}, error) {
+func mergeEnvConfigsData(configsByField map[string][]unstructured.Unstructured) (map[string]any, error) {
 	merged := map[string]any{}
 	for fieldPath, configs := range configsByField {
 		for _, c := range configs {

--- a/fn_test.go
+++ b/fn_test.go
@@ -773,6 +773,136 @@ func TestRunFunction(t *testing.T) {
 				},
 			},
 		},
+		"ToFieldPath": {
+			reason: "The Function should load into the specified toFieldPath",
+			args: args{
+				req: &fnv1.RunFunctionRequest{
+					Meta: &fnv1.RequestMeta{Tag: "hello"},
+					Input: resource.MustStructJSON(`{
+						"apiVersion": "template.fn.crossplane.io/v1beta1",
+						"kind": "Input",
+						"spec": {
+							"defaultData": {
+								"a": "from-default"
+							},
+							"environmentConfigs": [
+								{
+									"type": "Reference",
+									"ref": {
+										"name": "foo"
+									},
+									"toFieldPath": "foo"
+								},
+								{
+									"type": "Selector",
+									"selector": {
+										"mode": "Multiple",
+										"matchLabels": [
+											{
+												"type": "Value",
+												"key": "foo",
+												"value": "bar"
+											}
+										]
+									},
+									"toFieldPath": "foo.bar"
+								}
+							]
+						}
+					}`),
+					RequiredResources: map[string]*fnv1.Resources{
+						"environment-config-0": {
+							Items: []*fnv1.Resource{
+								{
+									Resource: resource.MustStructJSON(`{
+									"apiVersion": "apiextensions.crossplane.io/v1beta1",
+									"kind": "EnvironmentConfig",
+									"metadata": {
+										"name": "foo"
+									},
+									"data": {
+										"a": "from-foo"
+									}
+								}`),
+								},
+							},
+						},
+						"environment-config-1": {
+							Items: []*fnv1.Resource{
+								{
+									Resource: resource.MustStructJSON(`{
+									"apiVersion": "apiextensions.crossplane.io/v1beta1",
+									"kind": "EnvironmentConfig",
+									"metadata": {
+										"name": "first"
+									},
+									"data": {
+										"a": "from-label-select-first"
+									}
+								}`),
+								},
+								{
+									Resource: resource.MustStructJSON(`{
+									"apiVersion": "apiextensions.crossplane.io/v1beta1",
+									"kind": "EnvironmentConfig",
+									"metadata": {
+										"name": "second"
+									},
+									"data": {
+										"b": "from-label-select-second"
+									}
+								}`),
+								},
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				rsp: &fnv1.RunFunctionResponse{
+					Meta:    &fnv1.ResponseMeta{Tag: "hello", Ttl: durationpb.New(response.DefaultTTL)},
+					Results: []*fnv1.Result{},
+					Requirements: &fnv1.Requirements{
+						Resources: map[string]*fnv1.ResourceSelector{
+							"environment-config-0": {
+								ApiVersion: "apiextensions.crossplane.io/v1beta1",
+								Kind:       "EnvironmentConfig",
+								Match: &fnv1.ResourceSelector_MatchName{
+									MatchName: "foo",
+								},
+							},
+							"environment-config-1": {
+								ApiVersion: "apiextensions.crossplane.io/v1beta1",
+								Kind:       "EnvironmentConfig",
+								Match: &fnv1.ResourceSelector_MatchLabels{
+									MatchLabels: &fnv1.MatchLabels{
+										Labels: map[string]string{
+											"foo": "bar",
+										},
+									},
+								},
+							},
+						},
+					},
+					Context: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							FunctionContextKeyEnvironment: structpb.NewStructValue(resource.MustStructJSON(`{
+								"apiVersion": "internal.crossplane.io/v1alpha1",
+								"kind": "Environment",
+								"a": "from-default",
+								"foo": {
+									"a": "from-foo",
+									"bar": {
+										"a": "from-label-select-first",
+										"b": "from-label-select-second"
+									}
+								}
+							}`)),
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for name, tc := range cases {

--- a/input/v1beta1/composition_environment.go
+++ b/input/v1beta1/composition_environment.go
@@ -111,6 +111,10 @@ type EnvironmentSource struct {
 	// Selector selects EnvironmentConfig(s) via labels.
 	// +optional
 	Selector *EnvironmentSourceSelector `json:"selector,omitempty"`
+
+	// ToFieldPath specifies where in the environment to load the EnvironmentConfig(s).
+	// +optional
+	ToFieldPath *string `json:"toFieldPath,omitempty"`
 }
 
 // GetType returns the type of the environment source, returning the default if not set.


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Related to https://github.com/crossplane-contrib/function-environment-configs/issues/82 and https://crossplane.slack.com/archives/C08BBMDCH7W/p1769759797425119?thread_ts=1769438184.689339&cid=C08BBMDCH7W

When loading multiple EnvironmentConfig resources directly into the environment context at the root level, conflicts will occur if they overlap in structure. They can also easily conflict with keys used in patch-and-transform:

```yaml
---
apiVersion: apiextensions.crossplane.io/v1beta1
kind: EnvironmentConfig
metadata:
  name: foo
data:
  name: foo
---
apiVersion: apiextensions.crossplane.io/v1beta1
kind: EnvironmentConfig
metadata:
  name: bar
data:
  name: bar
---
apiVersion: apiextensions.crossplane.io/v1
kind: Composition
spec:
  pipeline:
    - input:
        apiVersion: environmentconfigs.fn.crossplane.io/v1beta1
        kind: Input
        spec:
          environmentConfigs:
            - type: Reference # environment is '{name: foo}'
              ref:
                name: foo
            - type: Reference # overrides 'name' in environment to 'bar'
              ref:
                name: bar
    - input:
        apiVersion: pt.fn.crossplane.io/v1beta1
        kind: Resources
        environment:
          patches:
            - type: FromCompositeFieldPath # overrides 'name' in environment to 'baz'
              fromFieldPath: metadata.name
              toFieldPath: name
```

I suggest adding `toFieldPath` to configure where in the environment to put the referenced resources. Using it as shown below, the composition above would end up with the environment `{foo: {name: foo}, bar: {name: bar}, name: baz}` instead of just `{name: baz}`.

```yaml
environmentConfigs:
  - type: Reference
    toFieldPath: foo
    ref:
      name: foo
  - type: Reference
    toFieldPath: bar
    ref:
      name: bar
```

Another alternative is to create the EnvironmentConfigs in such a way that they wont conflict (which you would still have to do when loading multiple EnvironmentConfigs with a single label selector). It however tightly binds the EnvironmentConfig content to the composition where it is used, instead of just containing the raw data:

```yaml
---
apiVersion: apiextensions.crossplane.io/v1beta1
kind: EnvironmentConfig
metadata:
  name: foo
data:
  foo:
    name: foo
```

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
