### PR TITLE
fix: upgrade Go to 1.26.2 to resolve stdlib CVEs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.25.0'
+  GO_VERSION: '1.26.2'
   GOLANGCI_VERSION: 'v2.11.4'
   DOCKER_BUILDX_VERSION: 'v0.24.0'
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # We use the latest Go 1.x version unless asked to use something else.
 # The GitHub Actions CI job sets this argument for a consistent Go version.
-ARG GO_VERSION=1
+ARG GO_VERSION=1.26.2
 
 # Setup the base environment. The BUILDPLATFORM is set automatically by Docker.
 # The --platform=${BUILDPLATFORM} flag tells Docker to build the function using

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/crossplane-contrib/function-environment-configs
 
-go 1.25.0
+go 1.26.2
 
 require (
 	github.com/alecthomas/kong v1.15.0


### PR DESCRIPTION
## Summary

Upgrades the Go toolchain from `1.25.0` to `1.26.2` to resolve **7 vulnerabilities** in the Go standard library identified by `govulncheck`, 5 of which are actively exercised by this binary.

## Vulnerabilities fixed

### Actively called (5)

| ID | Package | Description |
|----|---------|-------------|
| [GO-2026-4866](https://pkg.go.dev/vuln/GO-2026-4866) | `crypto/x509` | Auth bypass — case-sensitive `excludedSubtrees` name constraints |
| [GO-2026-4870](https://pkg.go.dev/vuln/GO-2026-4870) | `crypto/tls` | DoS — unauthenticated TLS 1.3 `KeyUpdate` causes persistent connection retention |
| [GO-2026-4947](https://pkg.go.dev/vuln/GO-2026-4947) | `crypto/x509` | DoS — unexpected work during certificate chain building |
| [GO-2026-4946](https://pkg.go.dev/vuln/GO-2026-4946) | `crypto/x509` | DoS — inefficient policy validation |
| [GO-2026-4865](https://pkg.go.dev/vuln/GO-2026-4865) | `html/template` | XSS — `JsBraceDepth` context tracking bug |

The `crypto/tls` and `crypto/x509` findings are directly relevant since this function uses mTLS for gRPC.

### Imported but not called (2)

| ID | Package |
|----|---------|
| [GO-2026-4864](https://pkg.go.dev/vuln/GO-2026-4864) | `internal/syscall/unix` |
| [GO-2026-4869](https://pkg.go.dev/vuln/GO-2026-4869) | `stdlib` |

## Changes

| File | Change |
|------|--------|
| `go.mod` | `go 1.25.0` → `go 1.26.2` |
| `Dockerfile` | `ARG GO_VERSION=1` → `ARG GO_VERSION=1.26.2` |
| `.github/workflows/ci.yml` | `GO_VERSION: '1.25.0'` → `GO_VERSION: '1.26.2'` |

## Test plan

- [x] `go build ./...` passes with Go 1.26.2
- [x] `go test ./...` passes — all existing tests green
- [x] `govulncheck ./...` reports **no vulnerabilities**

🤖 Generated with [Claude Code](https://claude.com/claude-code)