### PR TITLE
feat: match labels FromEnvironmentFieldPath

### DIFF
--- a/fn.go
+++ b/fn.go
@@ -61,7 +61,7 @@ func (f *Function) RunFunction(_ context.Context, req *fnv1.RunFunctionRequest) 
 		return rsp, nil
 	}
 
-	// Skip error check as the context key is not required and map conversion is nil safe.
+	// Skip key presence check as the context key is not required and map conversion is nil safe.
 	envCtx, _ := request.GetContextKey(req, FunctionContextKeyEnvironment)
 	env := envCtx.GetStructValue().AsMap()
 	// Note(phisco): We need to compute the selectors even if we already

--- a/fn.go
+++ b/fn.go
@@ -366,7 +366,7 @@ func buildMatchLabels(matchers []v1beta1.EnvironmentSourceSelectorLabelMatcher, 
 				continue
 			}
 			matchLabels[selector.Key] = value
-		case v1beta1.EnvironmentSourceSelectorLabelMatcherTypeFromEnvironemntFieldPath:
+		case v1beta1.EnvironmentSourceSelectorLabelMatcherTypeFromEnvironmentFieldPath:
 			value, err := fieldpath.Pave(env).GetString(*selector.ValueFromFieldPath)
 			if err != nil {
 				if !selector.FromFieldPathIsOptional() {

--- a/fn.go
+++ b/fn.go
@@ -63,7 +63,8 @@ func (f *Function) RunFunction(_ context.Context, req *fnv1.RunFunctionRequest) 
 
 	// Note(phisco): We need to compute the selectors even if we already
 	// requested them already at the previous iteration.
-	requirements, err := buildRequirements(req, in, oxr)
+	env, _ := request.GetContextKey(req, FunctionContextKeyEnvironment)
+	requirements, err := buildRequirements(in, oxr, env.GetStructValue().AsMap())
 	if err != nil {
 		response.Fatal(rsp, errors.Wrapf(err, "cannot build requirements"))
 		return rsp, nil
@@ -314,7 +315,7 @@ func lessAs[T cmp.Ordered](a, b any) (bool, error) {
 	return cmp.Less(av, bv), nil
 }
 
-func buildRequirements(req *fnv1.RunFunctionRequest, in *v1beta1.Input, xr *resource.Composite) (*fnv1.Requirements, error) {
+func buildRequirements(in *v1beta1.Input, xr *resource.Composite, env map[string]any) (*fnv1.Requirements, error) {
 	resources := make(map[string]*fnv1.ResourceSelector, len(in.Spec.EnvironmentConfigs))
 	for i, config := range in.Spec.EnvironmentConfigs {
 		extraResName := fmt.Sprintf("environment-config-%d", i)
@@ -328,34 +329,11 @@ func buildRequirements(req *fnv1.RunFunctionRequest, in *v1beta1.Input, xr *reso
 				},
 			}
 		case v1beta1.EnvironmentSourceTypeSelector:
-			matchLabels := map[string]string{}
-			for _, selector := range config.Selector.MatchLabels {
-				switch selector.GetType() {
-				case v1beta1.EnvironmentSourceSelectorLabelMatcherTypeValue:
-					// TODO validate value not to be nil
-					matchLabels[selector.Key] = *selector.Value
-				case v1beta1.EnvironmentSourceSelectorLabelMatcherTypeFromCompositeFieldPath:
-					value, err := fieldpath.Pave(xr.Resource.Object).GetString(*selector.ValueFromFieldPath)
-					if err != nil {
-						if !selector.FromFieldPathIsOptional() {
-							return nil, errors.Wrapf(err, "cannot get value from composite field path %q", *selector.ValueFromFieldPath)
-						}
-						continue
-					}
-					matchLabels[selector.Key] = value
-				case v1beta1.EnvironmentSourceSelectorLabelMatcherTypeFromEnvironemntFieldPath:
-					env, _ := request.GetContextKey(req, FunctionContextKeyEnvironment)
-					value, err := fieldpath.Pave(env.GetStructValue().AsMap()).GetString(*selector.ValueFromFieldPath)
-
-					if err != nil {
-						if !selector.FromFieldPathIsOptional() {
-							return nil, errors.Wrapf(err, "cannot get value from environment field path %q", *selector.ValueFromFieldPath)
-						}
-						continue
-					}
-					matchLabels[selector.Key] = value
-				}
+			matchLabels, err := buildMatchLabels(config.Selector.MatchLabels, xr, env)
+			if err != nil {
+				return nil, err
 			}
+
 			if len(matchLabels) == 0 {
 				continue
 			}
@@ -369,6 +347,38 @@ func buildRequirements(req *fnv1.RunFunctionRequest, in *v1beta1.Input, xr *reso
 		}
 	}
 	return &fnv1.Requirements{Resources: resources}, nil
+}
+
+func buildMatchLabels(matchers []v1beta1.EnvironmentSourceSelectorLabelMatcher, xr *resource.Composite, env map[string]any) (map[string]string, error) {
+	matchLabels := map[string]string{}
+
+	for _, selector := range matchers {
+		switch selector.GetType() {
+		case v1beta1.EnvironmentSourceSelectorLabelMatcherTypeValue:
+			// TODO validate value not to be nil
+			matchLabels[selector.Key] = *selector.Value
+		case v1beta1.EnvironmentSourceSelectorLabelMatcherTypeFromCompositeFieldPath:
+			value, err := fieldpath.Pave(xr.Resource.Object).GetString(*selector.ValueFromFieldPath)
+			if err != nil {
+				if !selector.FromFieldPathIsOptional() {
+					return nil, errors.Wrapf(err, "cannot get value from composite field path %q", *selector.ValueFromFieldPath)
+				}
+				continue
+			}
+			matchLabels[selector.Key] = value
+		case v1beta1.EnvironmentSourceSelectorLabelMatcherTypeFromEnvironemntFieldPath:
+			value, err := fieldpath.Pave(env).GetString(*selector.ValueFromFieldPath)
+			if err != nil {
+				if !selector.FromFieldPathIsOptional() {
+					return nil, errors.Wrapf(err, "cannot get value from environment field path %q", *selector.ValueFromFieldPath)
+				}
+				continue
+			}
+			matchLabels[selector.Key] = value
+		}
+	}
+
+	return matchLabels, nil
 }
 
 func mergeEnvConfigsData(configsByField map[string][]unstructured.Unstructured) (map[string]any, error) {

--- a/fn.go
+++ b/fn.go
@@ -61,10 +61,12 @@ func (f *Function) RunFunction(_ context.Context, req *fnv1.RunFunctionRequest) 
 		return rsp, nil
 	}
 
+	// Skip error check as the context key is not required and map conversion is nil safe.
+	envCtx, _ := request.GetContextKey(req, FunctionContextKeyEnvironment)
+	env := envCtx.GetStructValue().AsMap()
 	// Note(phisco): We need to compute the selectors even if we already
 	// requested them already at the previous iteration.
-	env, _ := request.GetContextKey(req, FunctionContextKeyEnvironment)
-	requirements, err := buildRequirements(in, oxr, env.GetStructValue().AsMap())
+	requirements, err := buildRequirements(in, oxr, env)
 	if err != nil {
 		response.Fatal(rsp, errors.Wrapf(err, "cannot build requirements"))
 		return rsp, nil

--- a/fn.go
+++ b/fn.go
@@ -18,7 +18,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	fnv1 "github.com/crossplane/function-sdk-go/proto/v1"
-	v1 "github.com/crossplane/function-sdk-go/proto/v1"
 	"github.com/crossplane/function-sdk-go/request"
 	"github.com/crossplane/function-sdk-go/resource"
 	"github.com/crossplane/function-sdk-go/response"
@@ -315,7 +314,7 @@ func lessAs[T cmp.Ordered](a, b any) (bool, error) {
 	return cmp.Less(av, bv), nil
 }
 
-func buildRequirements(req *v1.RunFunctionRequest, in *v1beta1.Input, xr *resource.Composite) (*fnv1.Requirements, error) {
+func buildRequirements(req *fnv1.RunFunctionRequest, in *v1beta1.Input, xr *resource.Composite) (*fnv1.Requirements, error) {
 	resources := make(map[string]*fnv1.ResourceSelector, len(in.Spec.EnvironmentConfigs))
 	for i, config := range in.Spec.EnvironmentConfigs {
 		extraResName := fmt.Sprintf("environment-config-%d", i)
@@ -345,11 +344,9 @@ func buildRequirements(req *v1.RunFunctionRequest, in *v1beta1.Input, xr *resour
 					}
 					matchLabels[selector.Key] = value
 				case v1beta1.EnvironmentSourceSelectorLabelMatcherTypeFromEnvironemntFieldPath:
-					env, ok := request.GetContextKey(req, FunctionContextKeyEnvironment)
-					if !ok && !selector.FromFieldPathIsOptional() {
-						return nil, errors.Errorf("cannot get value from environment field path %q", *selector.ValueFromFieldPath)
-					}
+					env, _ := request.GetContextKey(req, FunctionContextKeyEnvironment)
 					value, err := fieldpath.Pave(env.GetStructValue().AsMap()).GetString(*selector.ValueFromFieldPath)
+
 					if err != nil {
 						if !selector.FromFieldPathIsOptional() {
 							return nil, errors.Wrapf(err, "cannot get value from environment field path %q", *selector.ValueFromFieldPath)

--- a/fn.go
+++ b/fn.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	fnv1 "github.com/crossplane/function-sdk-go/proto/v1"
+	v1 "github.com/crossplane/function-sdk-go/proto/v1"
 	"github.com/crossplane/function-sdk-go/request"
 	"github.com/crossplane/function-sdk-go/resource"
 	"github.com/crossplane/function-sdk-go/response"
@@ -63,7 +64,7 @@ func (f *Function) RunFunction(_ context.Context, req *fnv1.RunFunctionRequest) 
 
 	// Note(phisco): We need to compute the selectors even if we already
 	// requested them already at the previous iteration.
-	requirements, err := buildRequirements(in, oxr)
+	requirements, err := buildRequirements(req, in, oxr)
 	if err != nil {
 		response.Fatal(rsp, errors.Wrapf(err, "cannot build requirements"))
 		return rsp, nil
@@ -314,7 +315,7 @@ func lessAs[T cmp.Ordered](a, b any) (bool, error) {
 	return cmp.Less(av, bv), nil
 }
 
-func buildRequirements(in *v1beta1.Input, xr *resource.Composite) (*fnv1.Requirements, error) {
+func buildRequirements(req *v1.RunFunctionRequest, in *v1beta1.Input, xr *resource.Composite) (*fnv1.Requirements, error) {
 	resources := make(map[string]*fnv1.ResourceSelector, len(in.Spec.EnvironmentConfigs))
 	for i, config := range in.Spec.EnvironmentConfigs {
 		extraResName := fmt.Sprintf("environment-config-%d", i)
@@ -338,7 +339,20 @@ func buildRequirements(in *v1beta1.Input, xr *resource.Composite) (*fnv1.Require
 					value, err := fieldpath.Pave(xr.Resource.Object).GetString(*selector.ValueFromFieldPath)
 					if err != nil {
 						if !selector.FromFieldPathIsOptional() {
-							return nil, errors.Wrapf(err, "cannot get value from field path %q", *selector.ValueFromFieldPath)
+							return nil, errors.Wrapf(err, "cannot get value from composite field path %q", *selector.ValueFromFieldPath)
+						}
+						continue
+					}
+					matchLabels[selector.Key] = value
+				case v1beta1.EnvironmentSourceSelectorLabelMatcherTypeFromEnvironemntFieldPath:
+					env, ok := request.GetContextKey(req, FunctionContextKeyEnvironment)
+					if !ok && !selector.FromFieldPathIsOptional() {
+						return nil, errors.Errorf("cannot get value from environment field path %q", *selector.ValueFromFieldPath)
+					}
+					value, err := fieldpath.Pave(env.GetStructValue().AsMap()).GetString(*selector.ValueFromFieldPath)
+					if err != nil {
+						if !selector.FromFieldPathIsOptional() {
+							return nil, errors.Wrapf(err, "cannot get value from environment field path %q", *selector.ValueFromFieldPath)
 						}
 						continue
 					}

--- a/fn.go
+++ b/fn.go
@@ -61,9 +61,10 @@ func (f *Function) RunFunction(_ context.Context, req *fnv1.RunFunctionRequest) 
 		return rsp, nil
 	}
 
-	// Skip key presence check as the context key is not required and map conversion is nil safe.
-	envCtx, _ := request.GetContextKey(req, FunctionContextKeyEnvironment)
-	env := envCtx.GetStructValue().AsMap()
+	var env map[string]any
+	if envCtx, ok := request.GetContextKey(req, FunctionContextKeyEnvironment); ok {
+		env = envCtx.GetStructValue().AsMap()
+	}
 	// Note(phisco): We need to compute the selectors even if we already
 	// requested them already at the previous iteration.
 	requirements, err := buildRequirements(in, oxr, env)

--- a/fn.go
+++ b/fn.go
@@ -136,6 +136,20 @@ func (f *Function) RunFunction(_ context.Context, req *fnv1.RunFunctionRequest) 
 	f.log.Debug("Computed Composition environment", "environment", v)
 	response.SetContextKey(rsp, FunctionContextKeyEnvironment, structpb.NewStructValue(v))
 
+	// Note(phisco): The requirements we computed above were based on the
+	// environment we were given, which doesn't yet contain the
+	// EnvironmentConfigs we just resolved. Recompute them against the merged
+	// environment so that FromEnvironmentFieldPath selectors can match on
+	// values coming from EnvironmentConfigs resolved by this same step.
+	// Requirements that grew make Crossplane call us again with the newly
+	// requested resources.
+	requirements, err = buildRequirements(in, oxr, out.Object)
+	if err != nil {
+		response.Fatal(rsp, errors.Wrapf(err, "cannot build requirements"))
+		return rsp, nil
+	}
+	rsp.Requirements = requirements
+
 	return rsp, nil
 }
 

--- a/fn_test.go
+++ b/fn_test.go
@@ -53,6 +53,15 @@ func TestRunFunction(t *testing.T) {
 							}`),
 						},
 					},
+					Context: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							FunctionContextKeyEnvironment: structpb.NewStructValue(resource.MustStructJSON(`{
+								"apiVersion": "internal.crossplane.io/v1alpha1",
+								"kind": "Environment",
+								"existingEnvSelectorLabel": "someMoreEnvBar"
+							}`)),
+						},
+					},
 					Input: resource.MustStructJSON(`{
 						"apiVersion": "template.fn.crossplane.io/v1beta1",
 						"kind": "Input",
@@ -108,6 +117,34 @@ func TestRunFunction(t *testing.T) {
 											}
 										]
 									}
+								},
+								{
+									"type": "Selector",
+									"selector": {
+										"mode": "Single",
+										"matchLabels": [
+											{
+												"type": "FromEnvironmentFieldPath",
+												"key": "someMoreEnvFoo",
+												"valueFromFieldPath": "missingEnvSelectorLabel",
+												"fromFieldPathPolicy": "Optional"
+											}
+										]
+									}
+								},
+								{
+									"type": "Selector",
+									"selector": {
+										"mode": "Single",
+										"matchLabels": [
+											{
+												"type": "FromEnvironmentFieldPath",
+												"key": "someMoreEnvFoo",
+												"valueFromFieldPath": "existingEnvSelectorLabel",
+												"fromFieldPathPolicy": "Required"
+											}
+										]
+									}
 								}
 							]
 						}
@@ -157,6 +194,27 @@ func TestRunFunction(t *testing.T) {
 									},
 								},
 							},
+							// environment-config-5 is not requested because it was optional
+							"environment-config-6": {
+								ApiVersion: "apiextensions.crossplane.io/v1beta1",
+								Kind:       "EnvironmentConfig",
+								Match: &fnv1.ResourceSelector_MatchLabels{
+									MatchLabels: &fnv1.MatchLabels{
+										Labels: map[string]string{
+											"someMoreEnvFoo": "someMoreEnvBar",
+										},
+									},
+								},
+							},
+						},
+					},
+					Context: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							FunctionContextKeyEnvironment: structpb.NewStructValue(resource.MustStructJSON(`{
+								"apiVersion": "internal.crossplane.io/v1alpha1",
+								"kind": "Environment",
+								"existingEnvSelectorLabel": "someMoreEnvBar"
+							}`)),
 						},
 					},
 				},
@@ -179,6 +237,15 @@ func TestRunFunction(t *testing.T) {
 									"existingEnvSelectorLabel": "someMoreBar"
 								}
 							}`),
+						},
+					},
+					Context: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							FunctionContextKeyEnvironment: structpb.NewStructValue(resource.MustStructJSON(`{
+								"apiVersion": "internal.crossplane.io/v1alpha1",
+								"kind": "Environment",
+								"existingEnvSelectorLabel": "someMoreEnvBar"
+							}`)),
 						},
 					},
 					RequiredResources: map[string]*fnv1.Resources{
@@ -276,6 +343,25 @@ func TestRunFunction(t *testing.T) {
 								},
 							},
 						},
+						"environment-config-6": {
+							Items: []*fnv1.Resource{
+								{
+									Resource: resource.MustStructJSON(`{
+									"apiVersion": "apiextensions.crossplane.io/v1beta1",
+									"kind": "EnvironmentConfig",
+									"metadata": {
+										"name": "my-sixth-env-config",
+										"labels": {
+											"someMoreEnvFoo": "someMoreEnvBar"
+										}
+									},
+									"data": {
+										"seventhKey": "seventhVal"
+									}
+								}`),
+								},
+							},
+						},
 					},
 					Input: resource.MustStructJSON(`{
 						"apiVersion": "template.fn.crossplane.io/v1beta1",
@@ -332,6 +418,33 @@ func TestRunFunction(t *testing.T) {
 											}
 										]
 									}
+								},{
+									"type": "Selector",
+									"selector": {
+										"mode": "Single",
+										"matchLabels": [
+											{
+												"type": "FromEnvironmentFieldPath",
+												"key": "someMoreEnvFoo",
+												"valueFromFieldPath": "missingEnvSelectorLabel",
+												"fromFieldPathPolicy": "Optional"
+											}
+										]
+									}
+								},
+								{
+									"type": "Selector",
+									"selector": {
+										"mode": "Single",
+										"matchLabels": [
+											{
+											  "type": "FromEnvironmentFieldPath",
+												"key": "someMoreEnvFoo",
+												"valueFromFieldPath": "existingEnvSelectorLabel",
+												"fromFieldPathPolicy": "Required"
+											}
+										]
+									}
 								}
 							]
 						}
@@ -381,6 +494,18 @@ func TestRunFunction(t *testing.T) {
 									},
 								},
 							},
+							// environment-config-5 is not requested because it was optional
+							"environment-config-6": {
+								ApiVersion: "apiextensions.crossplane.io/v1beta1",
+								Kind:       "EnvironmentConfig",
+								Match: &fnv1.ResourceSelector_MatchLabels{
+									MatchLabels: &fnv1.MatchLabels{
+										Labels: map[string]string{
+											"someMoreEnvFoo": "someMoreEnvBar",
+										},
+									},
+								},
+							},
 						},
 					},
 					Context: &structpb.Struct{
@@ -388,12 +513,14 @@ func TestRunFunction(t *testing.T) {
 							FunctionContextKeyEnvironment: structpb.NewStructValue(resource.MustStructJSON(`{
 								"apiVersion": "internal.crossplane.io/v1alpha1",
 								"kind": "Environment",
+								"existingEnvSelectorLabel": "someMoreEnvBar",
 								"firstKey": "firstVal",
 								"secondKey": "secondVal-ok",
 								"thirdKey": "thirdVal",
 								"fourthKey": "fourthVal-b",
 								"fifthKey": "fifthVal",
-								"sixthKey": "sixthVal"
+								"sixthKey": "sixthVal",
+								"seventhKey": "seventhVal"
 							}`)),
 						},
 					},
@@ -523,6 +650,22 @@ func TestRunFunction(t *testing.T) {
 											}
 										]
 									}
+								},
+								{
+									"type": "Selector",
+									"selector": {
+										"mode": "Multiple",
+										"minMatch": 0,
+										"maxMatch": 1,
+										"matchLabels": [
+											{
+											  "type": "FromEnvironmentFieldPath",
+												"key": "epd",
+												"valueFromFieldPath": "epd.name",
+												"fromFieldPathPolicy": "Optional"
+											}
+										]
+									}
 								}
 							]
 						}
@@ -614,6 +757,20 @@ func TestRunFunction(t *testing.T) {
 											{
 												"key": "epd",
 												"valueFromFieldPath": "spec.epd.name",
+												"fromFieldPathPolicy": "Optional"
+											}
+										]
+									}
+								},
+								{
+									"type": "Selector",
+									"selector": {
+										"mode": "Single",
+										"matchLabels": [
+											{
+												"type": "FromEnvironmentFieldPath",
+												"key": "epd",
+												"valueFromFieldPath": "edp.name",
 												"fromFieldPathPolicy": "Optional"
 											}
 										]

--- a/fn_test.go
+++ b/fn_test.go
@@ -1060,6 +1060,127 @@ func TestRunFunction(t *testing.T) {
 				},
 			},
 		},
+		"SelectorFromEnvironmentFieldPathResolvedInSameStep": {
+			reason: "The Function should request an EnvironmentConfig whose selector label value comes from an EnvironmentConfig resolved by this same step",
+			args: args{
+				req: &fnv1.RunFunctionRequest{
+					Meta: &fnv1.RequestMeta{Tag: "hello"},
+					Observed: &fnv1.State{
+						Composite: &fnv1.Resource{
+							Resource: resource.MustStructJSON(`{
+								"apiVersion": "test.crossplane.io/v1alpha1",
+								"kind": "XR",
+								"metadata": {
+									"name": "my-xr"
+								}
+							}`),
+						},
+					},
+					// No environment in the incoming context: nothing earlier in
+					// the pipeline produced one, so the second selector can only
+					// be resolved from the EnvironmentConfig we resolve here.
+					RequiredResources: map[string]*fnv1.Resources{
+						"environment-config-0": {
+							Items: []*fnv1.Resource{
+								{
+									Resource: resource.MustStructJSON(`{
+										"apiVersion": "apiextensions.crossplane.io/v1beta1",
+										"kind": "EnvironmentConfig",
+										"metadata": {
+											"name": "chain-a",
+											"labels": {
+												"stage": "prod"
+											}
+										},
+										"data": {
+											"team": "platform"
+										}
+									}`),
+								},
+							},
+						},
+					},
+					Input: resource.MustStructJSON(`{
+						"apiVersion": "environmentconfigs.fn.crossplane.io/v1beta1",
+						"kind": "Input",
+						"spec": {
+							"environmentConfigs": [
+								{
+									"type": "Selector",
+									"selector": {
+										"mode": "Single",
+										"matchLabels": [
+											{
+												"type": "Value",
+												"key": "stage",
+												"value": "prod"
+											}
+										]
+									}
+								},
+								{
+									"type": "Selector",
+									"selector": {
+										"mode": "Single",
+										"matchLabels": [
+											{
+												"type": "FromEnvironmentFieldPath",
+												"key": "team",
+												"valueFromFieldPath": "team",
+												"fromFieldPathPolicy": "Optional"
+											}
+										]
+									}
+								}
+							]
+						}
+					}`),
+				},
+			},
+			want: want{
+				rsp: &fnv1.RunFunctionResponse{
+					Meta: &fnv1.ResponseMeta{Tag: "hello", Ttl: durationpb.New(response.DefaultTTL)},
+					Requirements: &fnv1.Requirements{
+						Resources: map[string]*fnv1.ResourceSelector{
+							"environment-config-0": {
+								ApiVersion: "apiextensions.crossplane.io/v1beta1",
+								Kind:       "EnvironmentConfig",
+								Match: &fnv1.ResourceSelector_MatchLabels{
+									MatchLabels: &fnv1.MatchLabels{
+										Labels: map[string]string{
+											"stage": "prod",
+										},
+									},
+								},
+							},
+							// chain-a's data is part of the environment by the
+							// time we respond, so we can already tell Crossplane
+							// which EnvironmentConfig it selects.
+							"environment-config-1": {
+								ApiVersion: "apiextensions.crossplane.io/v1beta1",
+								Kind:       "EnvironmentConfig",
+								Match: &fnv1.ResourceSelector_MatchLabels{
+									MatchLabels: &fnv1.MatchLabels{
+										Labels: map[string]string{
+											"team": "platform",
+										},
+									},
+								},
+							},
+						},
+					},
+					Context: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							FunctionContextKeyEnvironment: structpb.NewStructValue(resource.MustStructJSON(`{
+								"apiVersion": "internal.crossplane.io/v1alpha1",
+								"kind": "Environment",
+								"team": "platform"
+							}`)),
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for name, tc := range cases {

--- a/input/v1beta1/composition_environment.go
+++ b/input/v1beta1/composition_environment.go
@@ -189,6 +189,10 @@ const (
 	// EnvironmentSourceSelectorLabelMatcherTypeFromCompositeFieldPath extracts
 	// the label value from a composite fieldpath.
 	EnvironmentSourceSelectorLabelMatcherTypeFromCompositeFieldPath EnvironmentSourceSelectorLabelMatcherType = "FromCompositeFieldPath"
+	// EnvironmentSourceSelectorLabelMatcherTypeFromEnvironemntFieldPath extracts
+	// the label value from environment fieldpath.
+	EnvironmentSourceSelectorLabelMatcherTypeFromEnvironemntFieldPath EnvironmentSourceSelectorLabelMatcherType = "FromEnvironmentFieldPath"
+
 	// EnvironmentSourceSelectorLabelMatcherTypeValue uses a literal as label
 	// value.
 	EnvironmentSourceSelectorLabelMatcherTypeValue EnvironmentSourceSelectorLabelMatcherType = "Value"
@@ -199,7 +203,7 @@ const (
 type EnvironmentSourceSelectorLabelMatcher struct {
 	// Type specifies where the value for a label comes from.
 	// +optional
-	// +kubebuilder:validation:Enum=FromCompositeFieldPath;Value
+	// +kubebuilder:validation:Enum=FromCompositeFieldPath;FromEnvironmentFieldPath;Value
 	// +kubebuilder:default=FromCompositeFieldPath
 	Type EnvironmentSourceSelectorLabelMatcherType `json:"type,omitempty"`
 

--- a/input/v1beta1/composition_environment.go
+++ b/input/v1beta1/composition_environment.go
@@ -189,9 +189,9 @@ const (
 	// EnvironmentSourceSelectorLabelMatcherTypeFromCompositeFieldPath extracts
 	// the label value from a composite fieldpath.
 	EnvironmentSourceSelectorLabelMatcherTypeFromCompositeFieldPath EnvironmentSourceSelectorLabelMatcherType = "FromCompositeFieldPath"
-	// EnvironmentSourceSelectorLabelMatcherTypeFromEnvironemntFieldPath extracts
+	// EnvironmentSourceSelectorLabelMatcherTypeFromEnvironmentFieldPath extracts
 	// the label value from environment fieldpath.
-	EnvironmentSourceSelectorLabelMatcherTypeFromEnvironemntFieldPath EnvironmentSourceSelectorLabelMatcherType = "FromEnvironmentFieldPath"
+	EnvironmentSourceSelectorLabelMatcherTypeFromEnvironmentFieldPath EnvironmentSourceSelectorLabelMatcherType = "FromEnvironmentFieldPath"
 
 	// EnvironmentSourceSelectorLabelMatcherTypeValue uses a literal as label
 	// value.

--- a/package/input/environmentconfigs.fn.crossplane.io_inputs.yaml
+++ b/package/input/environmentconfigs.fn.crossplane.io_inputs.yaml
@@ -113,6 +113,7 @@ spec:
                                   label comes from.
                                 enum:
                                 - FromCompositeFieldPath
+                                - FromEnvironmentFieldPath
                                 - Value
                                 type: string
                               value:


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

It is currently difficult to lookup EnvironmentConfigs based on values from environment. For example fetching one environment config (or resource, using function-extra-resources) and then fetch another environment config based on values in the first one.

The PR extends the types of `matchLabels` to include `FromEnvironmentFieldPath`.

It reuses the `valueFromFieldPath` and `fromFieldPathPolicy` fields used by `FromCompositeFieldPath`, as they did not contain _composite_, but could instead create `valueFromEnvironmentFieldPath` and `fromEnvironmentFieldPathPolicy`.

Tests are updated to also test `FromEnvironmentFieldPath` wherever `FromCompositeFieldPath` is tested.

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
