### PR TITLE
docs: document FromEnvironmentFieldPath rerun on updated value

### DIFF
--- a/input/v1beta1/composition_environment.go
+++ b/input/v1beta1/composition_environment.go
@@ -201,7 +201,15 @@ const (
 // An EnvironmentSourceSelectorLabelMatcher acts like a k8s label selector but
 // can draw the label value from a different path.
 type EnvironmentSourceSelectorLabelMatcher struct {
-	// Type specifies where the value for a label comes from.
+	// Type specifies where the value for a label comes from. With
+	// FromEnvironmentFieldPath, new resource requests are triggered if the
+	// referenced environment value changes upon resolving resources, meaning it
+	// can be initally absent and fetched into the environment by another entry
+	// within the same step. For it to work, fromFieldPathPolicy must be Optional
+	// as the value does not initially exist. Note that if some matchLabels do
+	// have values and others yet don't, only those with values will be filtered
+	// upon, potentially resulting in more resolved resources than desired.
+	//
 	// +optional
 	// +kubebuilder:validation:Enum=FromCompositeFieldPath;FromEnvironmentFieldPath;Value
 	// +kubebuilder:default=FromCompositeFieldPath

--- a/input/v1beta1/composition_environment.go
+++ b/input/v1beta1/composition_environment.go
@@ -204,12 +204,12 @@ type EnvironmentSourceSelectorLabelMatcher struct {
 	// Type specifies where the value for a label comes from. With
 	// FromEnvironmentFieldPath, new resource requests are triggered if the
 	// referenced environment value changes upon resolving resources, meaning it
-	// can be initally absent and fetched into the environment by another entry
+	// can be initially absent and fetched into the environment by another entry
 	// within the same step. For it to work, fromFieldPathPolicy must be Optional
-	// as the value does not initially exist. Note that if some matchLabels do
-	// have values and others yet don't, only those with values will be filtered
-	// upon, potentially resulting in more resolved resources than desired.
-	//
+	// as the value does not initially exist. Using Optional, note that if some
+	// matchLabels do have values and others yet don't, only those with values
+	// will be filtered upon, potentially resulting in more resolved resources
+	// than desired.
 	// +optional
 	// +kubebuilder:validation:Enum=FromCompositeFieldPath;FromEnvironmentFieldPath;Value
 	// +kubebuilder:default=FromCompositeFieldPath

--- a/package/input/environmentconfigs.fn.crossplane.io_inputs.yaml
+++ b/package/input/environmentconfigs.fn.crossplane.io_inputs.yaml
@@ -109,8 +109,15 @@ spec:
                                 type: string
                               type:
                                 default: FromCompositeFieldPath
-                                description: Type specifies where the value for a
-                                  label comes from.
+                                description: |-
+                                  Type specifies where the value for a label comes from. With
+                                  FromEnvironmentFieldPath, new resource requests are triggered if the
+                                  referenced environment value changes upon resolving resources, meaning it
+                                  can be initally absent and fetched into the environment by another entry
+                                  within the same step. For it to work, fromFieldPathPolicy must be Optional
+                                  as the value does not initially exist. Note that if some matchLabels do
+                                  have values and others yet don't, only those with values will be filtered
+                                  upon, potentially resulting in more resolved resources than desired.
                                 enum:
                                 - FromCompositeFieldPath
                                 - FromEnvironmentFieldPath

--- a/package/input/environmentconfigs.fn.crossplane.io_inputs.yaml
+++ b/package/input/environmentconfigs.fn.crossplane.io_inputs.yaml
@@ -113,11 +113,12 @@ spec:
                                   Type specifies where the value for a label comes from. With
                                   FromEnvironmentFieldPath, new resource requests are triggered if the
                                   referenced environment value changes upon resolving resources, meaning it
-                                  can be initally absent and fetched into the environment by another entry
+                                  can be initially absent and fetched into the environment by another entry
                                   within the same step. For it to work, fromFieldPathPolicy must be Optional
-                                  as the value does not initially exist. Note that if some matchLabels do
-                                  have values and others yet don't, only those with values will be filtered
-                                  upon, potentially resulting in more resolved resources than desired.
+                                  as the value does not initially exist. Using Optional, note that if some
+                                  matchLabels do have values and others yet don't, only those with values
+                                  will be filtered upon, potentially resulting in more resolved resources
+                                  than desired.
                                 enum:
                                 - FromCompositeFieldPath
                                 - FromEnvironmentFieldPath


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Documents https://github.com/crossplane-contrib/function-environment-configs/pull/119 (specifically https://github.com/tenstad/function-environment-configs/pull/1)

> The fix recomputes the requirements against the merged environment before
returning. Requirements that grew are how a Function asks to be called again, so
Crossplane fetches the newly selected EnvironmentConfigs and calls us once more;
they stabilise as soon as a pass selects nothing new.

> Two limits worth knowing, both of which I think are fine to document rather than
solve here:

> Required still fails on the first call, since the environment genuinely is
empty then — chained matchers have to be Optional. That is a sharp edge given
Required is the default, so it probably deserves a line in the field docs.
Each link in the chain costs roughly two iterations of Crossplane's
MaxRequirementsIterations (5), capping chains at about two levels.


Found it difficult to describe. Open for suggestions.

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
