### PR TITLE
fix(security): remediate CVE vulnerabilities in Go stdlib

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.26.5'
+  GO_VERSION: '1.26.6'
   GOLANGCI_VERSION: 'v2.11.4'
   DOCKER_BUILDX_VERSION: 'v0.24.0'
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/crossplane-contrib/function-environment-configs
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/alecthomas/kong v1.15.0


### PR DESCRIPTION
## Summary

This PR fixes CVE vulnerabilities identified by security scanning.

## Vulnerabilities Fixed

| CVE/GHSA | Severity | Package | Fixed Version |
|----------|----------|---------|---------------|
| GO-2026-5026 | High | stdlib | go1.26.6 |
| GO-2026-5972 | High | stdlib | go1.26.6 |
| GO-2026-6088 | High | stdlib | go1.26.6 |
| GO-2026-6089 | High | stdlib | go1.26.6 |
| GO-2026-5942 | High | stdlib | go1.26.6 |
| GO-2026-6090 | High | stdlib | go1.26.6 |
| GO-2026-6218 | Medium | stdlib | go1.26.6 |
| GO-2026-6091 | Medium | stdlib | go1.26.6 |

## Changes Made

- Updated `go` directive in `go.mod` from `1.26.5` to `1.26.6`
- Ran `go mod tidy` to update `go.sum`
- Updated `GO_VERSION` in `.github/workflows/ci.yml` to `1.26.6`

## References

- [GO-2026-5026](https://pkg.go.dev/vuln/GO-2026-5026)
- [GO-2026-5972](https://pkg.go.dev/vuln/GO-2026-5972)
- [GO-2026-6088](https://pkg.go.dev/vuln/GO-2026-6088)
- [GO-2026-6089](https://pkg.go.dev/vuln/GO-2026-6089)
- [GO-2026-5942](https://pkg.go.dev/vuln/GO-2026-5942)
- [GO-2026-6090](https://pkg.go.dev/vuln/GO-2026-6090)
- [GO-2026-6218](https://pkg.go.dev/vuln/GO-2026-6218)
- [GO-2026-6091](https://pkg.go.dev/vuln/GO-2026-6091)

## Verification

- [x] Rescanned with \`cve-scan\` skill after fixes
- [x] All listed vulnerabilities resolved